### PR TITLE
 CADC-1245:  CADC-8430:  (was s2739a, ta 13911:) support position and pixel cutouts as separate parameters

### DIFF
--- a/cadc-download-manager-server/src/main/resources/META-INF/resources/chooser.jsp
+++ b/cadc-download-manager-server/src/main/resources/META-INF/resources/chooser.jsp
@@ -159,18 +159,18 @@ var="langBundle" scope="request"/>
 <%     if ( validationErrList.size() > 0 ) {
 
 %>
-<p class="grid-12 color-attention">
-    The following validation errors were found. You can continue to process your other selections
-    or go back to fix these errors first. </p>
-<p class=grid-12">
-<ul>
+    <p class="grid-12 color-attention">
+        The following validation errors were found. You can continue to process your other selections
+        or go back to fix these errors first. </p>
+    <p class=grid-12">
+    <ul>
 
-    <c:forEach var="ex" items="<%= validationErrList %>">
-        <li>${ex.getLocalizedMessage()}</li>
-    </c:forEach>
+        <c:forEach var="ex" items="<%= validationErrList %>">
+            <li>${ex.getLocalizedMessage()}</li>
+        </c:forEach>
 
-</ul>
-</p>
+    </ul>
+    </p>
 
 <% }
 %>

--- a/cadc-download-manager-server/src/main/resources/META-INF/resources/chooser.jsp
+++ b/cadc-download-manager-server/src/main/resources/META-INF/resources/chooser.jsp
@@ -162,7 +162,7 @@ var="langBundle" scope="request"/>
     <p class="grid-12 color-attention">
         The following validation errors were found. You can continue to process your other selections
         or go back to fix these errors first. </p>
-    <p class=grid-12">
+    <p class="grid-12">
     <ul>
 
         <c:forEach var="ex" items="<%= validationErrList %>">

--- a/cadc-download-manager-server/src/test/java/ca/nrc/cadc/dlm/server/DLMInputHandlerTest.java
+++ b/cadc-download-manager-server/src/test/java/ca/nrc/cadc/dlm/server/DLMInputHandlerTest.java
@@ -3,7 +3,7 @@
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
  **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
  *
- *  (c) 2018.                            (c) 2018.
+ *  (c) 2020.                            (c) 2020.
  *  Government of Canada                 Gouvernement du Canada
  *  National Research Council            Conseil national de recherches
  *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -131,9 +131,9 @@ public class DLMInputHandlerTest {
 
         for (DownloadTuple dt: dtSet) {
             // each should have the same values
-            log.debug(dt.getID().toASCIIString() + dt.cutout.toString() + dt.label + "...");
+            log.debug(dt.getID().toASCIIString() + dt.posCutout.toString() + dt.label + "...");
             Assert.assertEquals("tuple ID does not match", testURI, dt.getID());
-            Assert.assertEquals("shape does not match", testShape, dt .cutout);
+            Assert.assertEquals("shape does not match", testShape, dt .posCutout);
             Assert.assertEquals("label does not match", LABEL_STR, dt.label);
         }
     }

--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTuple.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTuple.java
@@ -76,7 +76,8 @@ public class DownloadTuple {
     private static Logger log = Logger.getLogger(DownloadTuple.class);
 
     private final URI id;
-    public final Shape cutout;
+    public final Shape posCutout;
+    public final String pixelCutout;
     public final String label;
 
     /**
@@ -88,7 +89,8 @@ public class DownloadTuple {
             throw new IllegalArgumentException("id can not be null");
         }
         this.id = id;
-        this.cutout = null;
+        this.posCutout = null;
+        this.pixelCutout = null;
         this.label = null;
     }
 
@@ -102,7 +104,23 @@ public class DownloadTuple {
             throw new IllegalArgumentException("id can not be null");
         }
         this.id = id;
-        this.cutout = cutout;
+        this.posCutout = cutout;
+        this.pixelCutout = null;
+        this.label = null;
+    }
+
+    /**
+     * ctor
+     * @param id
+     * @param cutout
+     */
+    public DownloadTuple(URI id, String cutout) {
+        if (id == null) {
+            throw new IllegalArgumentException("id can not be null");
+        }
+        this.id = id;
+        this.posCutout = null;
+        this.pixelCutout = cutout;
         this.label = null;
     }
 
@@ -120,7 +138,27 @@ public class DownloadTuple {
             throw new IllegalArgumentException("cutout can not be null if label is defined.");
         }
         this.id = id;
-        this.cutout = cutout;
+        this.posCutout = cutout;
+        this.pixelCutout = null;
+        this.label = label;
+    }
+
+    /**
+     * ctor
+     * @param id
+     * @param cutout
+     * @param label
+     */
+    public DownloadTuple(URI id, String cutout, String label) {
+        if (id == null) {
+            throw new IllegalArgumentException("id can not be null");
+        }
+        if (label != null && cutout == null) {
+            throw new IllegalArgumentException("cutout can not be null if label is defined.");
+        }
+        this.id = id;
+        this.posCutout = null;
+        this.pixelCutout = cutout;
         this.label = label;
     }
 

--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTupleComparator.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTupleComparator.java
@@ -18,27 +18,39 @@ class DownloadTupleComparator implements Comparator<DownloadTuple> {
             return ret;
         }
 
-        // URIs are equal, move on to cutout - careful with null
-        if (lhs.cutout == null && rhs.cutout == null) {
+        // URIs are equal, move on to posCutout - careful with null
+        if (lhs.posCutout == null && rhs.posCutout == null) {
             ret = 0; // equal, continue to compare
         }
-        if (lhs.cutout == null && rhs.cutout != null) {
+        if (lhs.posCutout == null && rhs.posCutout != null) {
             return -1; // null before not null
         }
-        if (lhs.cutout != null && rhs.cutout == null) {
+        if (lhs.posCutout != null && rhs.posCutout == null) {
             return 1;
         }
-        if (lhs.cutout != null && rhs.cutout != null) {
+        if (lhs.posCutout != null && rhs.posCutout != null) {
             // both cutouts non-null: compare values
             ShapeFormat sf = new ShapeFormat();
-            String lhsCutout = sf.format(lhs.cutout);
-            String rhsCutout = sf.format(rhs.cutout);
+            String lhsCutout = sf.format(lhs.posCutout);
+            String rhsCutout = sf.format(rhs.posCutout);
 
             ret = lhsCutout.compareTo(rhsCutout);
             if (ret != 0) {
                 return ret;
             }
         }
+
+        // all else is equal, move on to pixelCutout - careful with null
+        if (lhs.pixelCutout == null && rhs.pixelCutout == null) {
+            ret = 0; // equal, continue to compare
+        }
+        if (lhs.pixelCutout == null && rhs.pixelCutout != null) {
+            return -1; // null before not null
+        }
+        if (lhs.pixelCutout != null && rhs.pixelCutout == null) {
+            return 1;
+        }
+
 
         // finally compare labels
         if (lhs.label == null && rhs.label == null) {

--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTupleFormat.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTupleFormat.java
@@ -245,7 +245,7 @@ public class DownloadTupleFormat {
         try {
             URI tmpURI = new URI(uriStr);
             return new DownloadTuple(tmpURI, cutoutStr);
-        } catch( URISyntaxException uriEx)  {
+        } catch (URISyntaxException uriEx)  {
             throw new DownloadTupleParsingException("invalid id for tuple:" + uriEx);
         }
     }

--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTupleFormat.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTupleFormat.java
@@ -79,7 +79,8 @@ import org.apache.log4j.Logger;
 
 public class DownloadTupleFormat {
     private static Logger log = Logger.getLogger(DownloadTupleFormat.class);
-
+    // Use this to determine which type of cutout is passed in
+    MultiDownloadGenerator multiDG = new MultiDownloadGenerator();
 
     /**
      * Parse DownloadTuple from internal format string.
@@ -130,8 +131,8 @@ public class DownloadTupleFormat {
             tmpLabel = null;
         }
 
-        Shape tmpShape = null;
         // Get any cutout that might be there
+        Shape tmpShape = null;
         if (tupleParts.length > 1) {
             String sd = tupleParts[1];
             if (sd.length() > 1) {
@@ -139,6 +140,7 @@ public class DownloadTupleFormat {
                 // guaranteed to be there due to
                 // check for equal occurrences of { and } above.
                 String tmpShapeStr = sd.substring(0, sd.length() - 1);
+                // put off parsing until id is parsed
                 log.debug("cutout string: " + tmpShapeStr);
                 if (StringUtil.hasLength(tmpShapeStr)) {
                     try {
@@ -157,8 +159,6 @@ public class DownloadTupleFormat {
                 // invalid format
                 throw new DownloadTupleParsingException("invalid cutout: " + tupleStr);
             }
-        } else {
-            tmpShape = null;
         }
 
         // Get tuple URI - should at least have this.
@@ -176,9 +176,9 @@ public class DownloadTupleFormat {
             throw new DownloadTupleParsingException("zero length id found: " + tupleStr);
         }
 
+
         return new DownloadTuple(tmpURI, tmpShape, tmpLabel);
     }
-
 
     private int getCount(final String input, final String regexp) {
         final Pattern p = Pattern.compile(regexp);
@@ -192,7 +192,6 @@ public class DownloadTupleFormat {
         return count;
     }
 
-
     /**
      * Output DownloadTuple in internal format
      * @param tuple
@@ -201,9 +200,9 @@ public class DownloadTupleFormat {
     public String format(DownloadTuple tuple) {
         String tupleStr = tuple.getID().toString();
 
-        if (tuple.cutout != null) {
+        if (tuple.posCutout != null) {
             ShapeFormat sf = new ShapeFormat();
-            tupleStr += "{" + sf.format(tuple.cutout) + "}";
+            tupleStr += "{" + sf.format(tuple.posCutout) + "}";
         }
 
         if (StringUtil.hasLength(tuple.label)) {
@@ -233,6 +232,22 @@ public class DownloadTupleFormat {
             tupleStr += "{" + part3 + "}";
         }
         return parse(tupleStr);
+    }
+
+    /**
+     * Create a DownloadTuple using a URI string and a cutout string that
+     * @param uriStr
+     * @param cutoutStr
+     * @return
+     * @throws DownloadTupleParsingException
+     */
+    public DownloadTuple parsePixelStringTuple(String uriStr, String cutoutStr) throws DownloadTupleParsingException  {
+        try {
+            URI tmpURI = new URI(uriStr);
+            return new DownloadTuple(tmpURI, cutoutStr);
+        } catch( URISyntaxException uriEx)  {
+            throw new DownloadTupleParsingException("invalid id for tuple:" + uriEx);
+        }
     }
 
 }

--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTupleFormat.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTupleFormat.java
@@ -85,6 +85,8 @@ public class DownloadTupleFormat {
     /**
      * Parse DownloadTuple from internal format string.
      * @param tupleStr String representing a tuple
+     * @return DownloadTuple populated with information from the input
+     * @throws DownloadTupleParsingException
      */
     public DownloadTuple parse(String tupleStr) throws DownloadTupleParsingException {
         log.debug("tuple string input: " + tupleStr);
@@ -105,7 +107,6 @@ public class DownloadTupleFormat {
 
         // Split out the tuple parts
         String [] tupleParts = tupleStr.split("\\{");
-        String tmpTupleID;
         String tmpLabel;
 
         if (tupleParts.length > 3) {
@@ -175,8 +176,7 @@ public class DownloadTupleFormat {
             // invalid format - has to at least be a single URI passed in
             throw new DownloadTupleParsingException("zero length id found: " + tupleStr);
         }
-
-
+        
         return new DownloadTuple(tmpURI, tmpShape, tmpLabel);
     }
 
@@ -194,8 +194,8 @@ public class DownloadTupleFormat {
 
     /**
      * Output DownloadTuple in internal format
-     * @param tuple
-     * @return
+     * @param tuple to format
+     * @return string representation of tuple
      */
     public String format(DownloadTuple tuple) {
         String tupleStr = tuple.getID().toString();
@@ -217,10 +217,10 @@ public class DownloadTupleFormat {
      * Note: this code can be used at the tail end of parsing JSON input, or other blob-type data
      * that is provided in String format. Use this function to leverage the validation code found
      * in parse(internal_format_string).
-     * @param part1
-     * @param part2
-     * @param part3
-     * @return
+     * @param part1 string representation of URI for download
+     * @param part2 (Optional) DALI string representation of cutout
+     * @param part3 (Optional) label to add to download request
+     * @return DownloadTuple populated with tuple information provided.
      * @throws DownloadTupleParsingException
      */
     public DownloadTuple parseUsingInternalFormat(String part1, String part2, String part3) throws DownloadTupleParsingException {
@@ -235,10 +235,10 @@ public class DownloadTupleFormat {
     }
 
     /**
-     * Create a DownloadTuple using a URI string and a cutout string that
-     * @param uriStr
-     * @param cutoutStr
-     * @return
+     * Create a DownloadTuple using a URI string and a cutout string.
+     * @param uriStr URI for download
+     * @param cutoutStr pixel cutout to apply to download
+     * @return DownloadTuple popuplated with URI and cutout.
      * @throws DownloadTupleParsingException
      */
     public DownloadTuple parsePixelStringTuple(String uriStr, String cutoutStr) throws DownloadTupleParsingException  {

--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/handlers/AdDownloadGenerator.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/handlers/AdDownloadGenerator.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2011, 2020                       (c) 2011, 2020
+*  (c) 2020                             (c) 2020
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -75,9 +75,11 @@ import ca.nrc.cadc.dlm.DownloadTuple;
 import ca.nrc.cadc.dlm.FailIterator;
 import ca.nrc.cadc.dlm.SingleDownloadIterator;
 import ca.nrc.cadc.util.CaseInsensitiveStringComparator;
+import ca.nrc.cadc.util.StringUtil;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -102,12 +104,11 @@ public class AdDownloadGenerator implements DownloadGenerator {
     //        PARAMS.add("cutout");
     //        PARAMS.add("runid");
     //    }
-    // TODO: #technical debt; cutout with [#] format still needs to be
-    //  handled
+    // TODO: #technical debt:
     // Q: what happens with 'logkey' and 'logvalue' above?
 
     private AdSchemeHandler ad;
-    private Map<String, List<String>> params;
+    private Map<String, String> queryParams = new HashMap<String, String>();
 
     public AdDownloadGenerator() {
         this.ad = new AdSchemeHandler();
@@ -120,46 +121,44 @@ public class AdDownloadGenerator implements DownloadGenerator {
     public Iterator<DownloadDescriptor> downloadIterator(DownloadTuple dt) {
         try {
             URL url = ad.getURL(dt.getID());
-            StringBuilder sb = new StringBuilder(url.toExternalForm());
+            log.debug("url string bfore query processing: " + url.toString());
 
             if (this.runID != null) {
-                sb.append("?runid=");
-                sb.append(this.runID);
+                queryParams.put("runid", this.runID);
             }
-            url = new URL(sb.toString());
 
-            // TODO: all of this is likely to be yanked, or have to be
-            // dealt with at some time in future when the cutout & other parameters
-            // are somehow represented here
-            //            if (params != null) {
-            //                StringBuilder sb = new StringBuilder(url.toExternalForm());
-            //                boolean first = true;
-            //                Iterator<Map.Entry<String, List<String>>> i = params.entrySet().iterator();
-            //                while (i.hasNext()) {
-            //                    Map.Entry<String, List<String>> me = i.next();
-            //                    if (PARAMS.contains(me.getKey()) && me.getValue() != null) {
-            //                        for (String v : me.getValue()) {
-            //                            if (first) {
-            //                                sb.append("?");
-            //                            } else {
-            //                                sb.append("&");
-            //                            }
-            //                            first = false;
-            //                            sb.append(me.getKey());
-            //                            sb.append("=");
-            //                            sb.append(URLEncoder.encode(v, "UTF-8"));
-            //                        }
-            //                    }
-            //                }
-            //                url = new URL(sb.toString());
-            //            }
+            if (StringUtil.hasLength(dt.pixelCutout)) {
+                // pixelCutout is a passthrough value - no validation
+                // has been done on it.
+                queryParams.put("cutout", dt.pixelCutout);
+            }
+
+            if (!queryParams.isEmpty()) {
+                StringBuilder sb = new StringBuilder(url.toExternalForm());
+                boolean first = true;
+                Iterator<Map.Entry<String, String>> i = queryParams.entrySet().iterator();
+                log.debug("url string: " + sb.toString());
+                while (i.hasNext()) {
+                    Map.Entry<String, String> me = i.next();
+                    if (me.getValue() != null) {
+                        if (first) {
+                            sb.append("?");
+                        } else {
+                            sb.append("&");
+                        }
+                        first = false;
+                        sb.append(me.getKey());
+                        sb.append("=");
+                        sb.append(URLEncoder.encode(me.getValue(), "UTF-8"));
+                    }
+                }
+                log.debug("url string: " + sb.toString());
+                url = new URL(sb.toString());
+            }
             return new SingleDownloadIterator(dt, url);
         } catch (Exception ex) {
             return new FailIterator(dt, "failed to resolve URI: " + ex.getMessage());
         }
     }
 
-    public void setParameters(Map<String, List<String>> params) {
-        this.params = params;
-    }
 }

--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/handlers/AdDownloadGenerator.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/handlers/AdDownloadGenerator.java
@@ -95,17 +95,6 @@ import org.apache.log4j.Logger;
 public class AdDownloadGenerator implements DownloadGenerator {
     private static final Logger log = Logger.getLogger(AdDownloadGenerator.class);
     private String runID;
-    //    private static final Set<String> PARAMS;
-    //
-    //    static {
-    //        PARAMS = new TreeSet<String>(new CaseInsensitiveStringComparator());
-    //        PARAMS.add("logkey");
-    //        PARAMS.add("logvalue");
-    //        PARAMS.add("cutout");
-    //        PARAMS.add("runid");
-    //    }
-    // TODO: #technical debt:
-    // Q: what happens with 'logkey' and 'logvalue' above?
 
     private AdSchemeHandler ad;
     private Map<String, String> queryParams = new HashMap<String, String>();

--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/handlers/DataLinkClient.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/handlers/DataLinkClient.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2011.                            (c) 2011.
+*  (c) 2020.                            (c) 2020.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -167,7 +167,7 @@ public class DataLinkClient implements DownloadGenerator {
             sb.append(NetUtil.encode(dt.getID().toASCIIString()));
 
             // download only request
-            if (dt.cutout == null) {
+            if (dt.posCutout == null) {
                 sb.append("&request=").append(DOWNLOAD_REQUEST); // custom
             }
 
@@ -235,7 +235,7 @@ public class DataLinkClient implements DownloadGenerator {
             VOTableTable links = res.getTable();
             this.downloadTuple = dt;
 
-            if (dt.cutout == null) {
+            if (dt.posCutout == null) {
                 downloadOnly = true;
             }
 
@@ -421,21 +421,21 @@ public class DataLinkClient implements DownloadGenerator {
                     } else if (CUTOUT.equals(sem)) {
                         String standardID = getServiceProperty(sdef, "standardID");
                         if (Standards.SODA_SYNC_10.toString().equals(standardID)) {
-                            if (downloadTuple.cutout != null) {
+                            if (downloadTuple.posCutout != null) {
                                 ShapeFormat sf = new ShapeFormat();
-                                curParams = "POS=" +  NetUtil.encode(sf.format(downloadTuple.cutout));
+                                curParams = "POS=" +  NetUtil.encode(sf.format(downloadTuple.posCutout));
                             }
                             if (downloadTuple.label != null) {
                                 curParams += "&LABEL=" + NetUtil.encode(downloadTuple.label);
                             }
-                            log.debug("pass: " + url + " semantics: " + sem + " cutout: " + downloadTuple.cutout);
+                            log.debug("pass: " + url + " semantics: " + sem + " cutout: " + downloadTuple.posCutout);
                         } else {
                             curRow = null;
-                            log.debug("skip: " + url + " standardID: " + standardID + " cutout: " + downloadTuple.cutout);
+                            log.debug("skip: " + url + " standardID: " + standardID + " cutout: " + downloadTuple.posCutout);
                         }
-                    } else if (downloadTuple.cutout != null) {
+                    } else if (downloadTuple.posCutout != null) {
                         curRow = null;
-                        log.debug("skip: " + url + " semantics: " + sem + " cutout: " + downloadTuple.cutout);
+                        log.debug("skip: " + url + " semantics: " + sem + " cutout: " + downloadTuple.posCutout);
                     } else {
                         log.debug("pass: " + url + " semantics: " + sem);
                     }

--- a/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleComparatorTest.java
+++ b/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleComparatorTest.java
@@ -105,7 +105,7 @@ public class DownloadTupleComparatorTest {
         d2 = new DownloadTuple(new URI("test://uri/2"), sf.parse(circleShape2), "circleLabel2");
         d3 = new DownloadTuple(new URI("test://uri/3"), sf.parse(polygonShape), "polygonLabel");
 
-        d4 = new DownloadTuple(new URI("test://uri/1"), null, null);
+        d4 = new DownloadTuple(new URI("test://uri/1"));
         d5 = new DownloadTuple(new URI("test://uri/2"), sf.parse(circleShape2), null);
     }
 
@@ -120,7 +120,7 @@ public class DownloadTupleComparatorTest {
 
         Assert.assertTrue("Duplicate was added", testTreeSet.size() == 2 );
 
-        dup = new DownloadTuple(new URI("test://uri/1"), null, null);
+        dup = new DownloadTuple(new URI("test://uri/1"));
         testTreeSet.add(d4);
         testTreeSet.add(dup);
 

--- a/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleTest.java
+++ b/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleTest.java
@@ -98,7 +98,7 @@ public class DownloadTupleTest extends DownloadTupleTestBase {
 
     @Test
     public void testURIOnly() throws Exception {
-        DownloadTuple dt = new DownloadTuple(new URI(URI_STR), null, null);
+        DownloadTuple dt = new DownloadTuple(new URI(URI_STR));
         log.debug("uri only: " + dt.getID());
         Assert.assertEquals("ctor didn't work", dt.getID(),expectedURI);
     }
@@ -107,14 +107,36 @@ public class DownloadTupleTest extends DownloadTupleTestBase {
     public void testURIShape() throws Exception {
         DownloadTuple dt = new DownloadTuple(new URI(URI_STR), sf.parse(SHAPE_STR), null);
         Assert.assertEquals("ctor didn't work for id", dt.getID(), expectedURI);
-        Assert.assertEquals("ctor didn't work for cutout", dt.cutout, expectedCutout);
+        Assert.assertEquals("ctor didn't work for posCutout", expectedCutout, dt.posCutout );
+        Assert.assertEquals("ctor didn't work for pixelCutout", null, dt.pixelCutout );
     }
 
     @Test
-    public void testAllParams() throws Exception {
+    public void testShapeCutoutTuple() throws Exception {
         DownloadTuple dt = new DownloadTuple(new URI(URI_STR), sf.parse(SHAPE_STR), LABEL_STR);
-        Assert.assertEquals("ctor didn't work for id", dt.getID(), expectedURI);
-        Assert.assertEquals("ctor didn't work for cutout", dt.cutout, expectedCutout);
-        Assert.assertEquals("ctor didn't work for label", dt.label, expectedLabel);
+        Assert.assertEquals("ctor didn't work for id", expectedURI, dt.getID());
+        Assert.assertEquals("ctor didn't work for cutout", expectedCutout, dt.posCutout );
+        Assert.assertEquals("ctor didn't work for label", expectedLabel, dt.label);
+    }
+
+    // Valid tests only for pixelCutout as it is not validated
+    @Test
+    public void testPixelCutoutFullTuple() throws Exception {
+        String expectedPixelCutout = "[2]";
+        DownloadTuple dt = new DownloadTuple(new URI(URI_STR), "[2]", LABEL_STR);
+        Assert.assertEquals("ctor didn't work for id", expectedURI, dt.getID());
+        Assert.assertEquals("ctor didn't work for posCutout", null, dt.posCutout );
+        Assert.assertEquals("ctor didn't work for pixelCutout", expectedPixelCutout, dt.pixelCutout );
+        Assert.assertEquals("ctor didn't work for label", expectedLabel, dt.label);
+    }
+
+    @Test
+    public void testPixelCutoutTuple() throws Exception {
+        String expectedPixelCutout = "[2]";
+        DownloadTuple dt = new DownloadTuple(new URI(URI_STR), "[2]");
+        Assert.assertEquals("ctor didn't work for id", expectedURI, dt.getID());
+        Assert.assertEquals("ctor didn't work for posCutout", null, dt.posCutout );
+        Assert.assertEquals("ctor didn't work for pixelCutout", expectedPixelCutout, dt.pixelCutout );
+        Assert.assertEquals("ctor didn't work for label", null, dt.label);
     }
 }

--- a/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleTestBase.java
+++ b/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleTestBase.java
@@ -1,4 +1,3 @@
-
 /*
  ************************************************************************
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
@@ -79,7 +78,7 @@ import org.junit.Before;
 
 public abstract class DownloadTupleTestBase {
     private static Logger log = Logger.getLogger(DownloadTupleTestBase.class);
-    protected static String URI_STR = "test://mysite.ca/path/1";
+    protected static String URI_STR = "ivo://mysite.ca/path/1";
     // Knowing this doesn't make sense as a polygon, it adheres to the format needed
     // by cadc-dali PolygonFormat
     protected static String SHAPE_STR = "polygon 0.0 0.0 0.0 0.0 0.0 0.0";

--- a/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/client/MainArgParsingTest.java
+++ b/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/client/MainArgParsingTest.java
@@ -113,7 +113,7 @@ public class MainArgParsingTest {
 
             for (DownloadTuple dt: tupleList) {
                 assertEquals("tupleID didn't parse correctly", testURI, dt.getID());
-                assertEquals("shapeDescriptor didn't parse correctly", expectedCutout, dt.cutout);
+                assertEquals("shapeDescriptor didn't parse correctly", expectedCutout, dt.posCutout);
                 assertEquals("tupleID didn't parse correctly", "testLabel_1011", dt.label);
             }
 
@@ -140,10 +140,10 @@ public class MainArgParsingTest {
 
             for (DownloadTuple dt: tupleList) {
                 if (dt.getID().toString().contains("testDevice2")) {
-                    assertEquals("shapeDescriptor didn't parse correctly", expectedCutout2, dt.cutout);
+                    assertEquals("shapeDescriptor didn't parse correctly", expectedCutout2, dt.posCutout);
                     assertEquals("tupleID didn't parse correctly", "testLabel_98", dt.label);
                 } else if (dt.getID().toString().contains("testDevice1")) {
-                    assertEquals("shapeDescriptor didn't parse correctly", expectedCutout1, dt.cutout);
+                    assertEquals("shapeDescriptor didn't parse correctly", expectedCutout1, dt.posCutout);
                     assertEquals("tupleID didn't parse correctly", "testLabel_1011", dt.label);
                 } else {
                     Assert.fail("IDs did not parse correctly");
@@ -211,7 +211,7 @@ public class MainArgParsingTest {
 
             for (DownloadTuple dt: tupleList) {
                 assertEquals("URI didn't parse correctly", testURI, dt.getID());
-                assertEquals("shapeDescriptor didn't parse correctly", expectedCutout1, dt.cutout);
+                assertEquals("shapeDescriptor didn't parse correctly", expectedCutout1, dt.posCutout);
                 assertEquals("tupleID didn't parse correctly", "testLabel_1011", dt.label);
             }
 
@@ -236,7 +236,7 @@ public class MainArgParsingTest {
 
             for (DownloadTuple dt: tupleList) {
                 assertEquals("URI didn't parse correctly", testURI, dt.getID());
-                assertEquals("shapeDescriptor should be null", null, dt.cutout);
+                assertEquals("shapeDescriptor should be null", null, dt.posCutout);
                 assertEquals("tupleID didn't parse correctly", null, dt.label);
             }
 
@@ -261,7 +261,7 @@ public class MainArgParsingTest {
             for (DownloadTuple dt: tupleList) {
                 if (dt.getID().toString().contains("testDevice1") ||
                     dt.getID().toString().contains("testDevice2")) {
-                    assertEquals("shapeDescriptor should be null", null, dt.cutout);
+                    assertEquals("shapeDescriptor should be null", null, dt.posCutout);
                     assertEquals("tupleID didn't parse correctly", null, dt.label);
                 }
             }
@@ -287,7 +287,7 @@ public class MainArgParsingTest {
 
             for (DownloadTuple dt: tupleList) {
                 assertEquals("URI didn't parse correctly", testURI, dt.getID());
-                assertEquals("shapeDescriptor didn't parse correctly", expectedCutout1, dt.cutout);
+                assertEquals("shapeDescriptor didn't parse correctly", expectedCutout1, dt.posCutout);
                 assertEquals("tupleID should be null", null, dt.label);
             }
 
@@ -314,10 +314,10 @@ public class MainArgParsingTest {
 
             for (DownloadTuple dt: tupleList) {
                 if (dt.getID().toString().contains("testDevice2")) {
-                    assertEquals("shapeDescriptor didn't parse correctly", expectedCutout2, dt.cutout);
+                    assertEquals("shapeDescriptor didn't parse correctly", expectedCutout2, dt.posCutout);
                     assertEquals("tupleID didn't parse correctly", null, dt.label);
                 } else if (dt.getID().toString().contains("testDevice1")) {
-                    assertEquals("shapeDescriptor didn't parse correctly", expectedCutout1, dt.cutout);
+                    assertEquals("shapeDescriptor didn't parse correctly", expectedCutout1, dt.posCutout);
                     assertEquals("tupleID didn't parse correctly", "testLabel_1011", dt.label);
                 } else {
                     Assert.fail("IDs did not parse correctly");
@@ -348,7 +348,7 @@ public class MainArgParsingTest {
 
             for (DownloadTuple dt: tupleList) {
                 assertEquals("URI didn't parse correctly", testURI, dt.getID());
-                assertEquals("shapeDescriptor didn't parse correctly", expectedCutout1, dt.cutout);
+                assertEquals("shapeDescriptor didn't parse correctly", expectedCutout1, dt.posCutout);
                 assertEquals("tupleID didn't parse correctly", "testLabel_98", dt.label);
             }
 

--- a/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/handlers/AdDownloadGeneratorTest.java
+++ b/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/handlers/AdDownloadGeneratorTest.java
@@ -171,7 +171,7 @@ public class AdDownloadGeneratorTest
             Assert.fail("unexpected exception: " + unexpected);
         }
     }
-    
+
     private static String encodeString(String str)
     {
         try { return URLEncoder.encode(str, "UTF-8"); }

--- a/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/handlers/AdDownloadGeneratorTest.java
+++ b/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/handlers/AdDownloadGeneratorTest.java
@@ -2,7 +2,7 @@
  ************************************************************************
  ****  C A N A D I A N   A S T R O N O M Y   D A T A   C E N T R E  *****
  *
- * (c) 2011.                            (c) 2011.
+ * (c) 2020.                            (c) 2020.
  * National Research Council            Conseil national de recherches
  * Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
  * All rights reserved                  Tous droits reserves
@@ -31,6 +31,7 @@ package ca.nrc.cadc.dlm.handlers;
 import ca.nrc.cadc.auth.AuthMethod;
 import ca.nrc.cadc.dlm.DownloadDescriptor;
 import ca.nrc.cadc.dlm.DownloadTuple;
+import ca.nrc.cadc.dlm.DownloadTupleFormat;
 import ca.nrc.cadc.reg.Standards;
 import ca.nrc.cadc.reg.client.RegistryClient;
 import ca.nrc.cadc.util.Log4jInit;
@@ -43,11 +44,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 /**
  *
@@ -56,9 +53,10 @@ import java.util.Map;
 public class AdDownloadGeneratorTest
 {
     private static final Logger log = Logger.getLogger(AdDownloadGeneratorTest.class);
+    private DownloadTupleFormat df = new DownloadTupleFormat();
     static
     {
-        Log4jInit.setLevel("ca.nrc.cadc.dlm.handlers", Level.INFO);
+        Log4jInit.setLevel("ca.nrc.cadc.dlm.handlers", Level.DEBUG);
     }
 
     URL baseURL;
@@ -86,7 +84,7 @@ public class AdDownloadGeneratorTest
             AdDownloadGenerator gen = new AdDownloadGenerator();
             
             URI uri = new URI("ad", "SomeArchive/SomeFileID", null);
-            DownloadTuple dt = new DownloadTuple(uri, null, null);
+            DownloadTuple dt = new DownloadTuple(uri);
             Iterator<DownloadDescriptor> iter = gen.downloadIterator(dt);
 
             Assert.assertNotNull(iter);
@@ -109,33 +107,23 @@ public class AdDownloadGeneratorTest
         }
     }
     
-//    @Test
-    public void testParams()
-    // TODO: test commented out until this format of cutout is handled again
-    // after move to using DownloadTuple and DownloadRequest as inputs
+    @Test
+    public void testURLPlusCutout()
     {
         try
         {
-            Map<String,List<String>> params = new HashMap<String,List<String>>();
-            List<String> ss = new ArrayList<String>();
-            ss.add("[1]");
-            ss.add("[2]");
-            params.put("cutout", ss);
-            ss = new ArrayList<String>();
-            ss.add("rid");
-            params.put("runid", ss);
-
             AdDownloadGenerator gen = new AdDownloadGenerator();
-            gen.setParameters(params);
+            gen.setRunID("testRunID");
 
             URI uri = new URI("ad", "SomeArchive/SomeFileID", null);
-            DownloadTuple dt = new DownloadTuple(uri, null, null);
+            DownloadTuple dt = new DownloadTuple(uri, "[1]");
             Iterator<DownloadDescriptor> iter = gen.downloadIterator(dt);
 
             Assert.assertNotNull(iter);
             Assert.assertTrue(iter.hasNext());
 
             DownloadDescriptor dd = iter.next();
+            log.debug(dd.status);
             Assert.assertEquals(DownloadDescriptor.OK, dd.status);
 
             Assert.assertEquals("uri", uri.toASCIIString(), dd.uri);
@@ -145,9 +133,11 @@ public class AdDownloadGeneratorTest
             Assert.assertEquals("path", baseURL.getPath() + "/SomeArchive/SomeFileID", dd.url.getPath());
 
             Assert.assertNotNull("query", dd.url.getQuery());
-            Assert.assertTrue("runID", dd.url.getQuery().contains("runid=rid"));
-            Assert.assertTrue("cutout1", dd.url.getQuery().contains( "cutout="+encodeString("[1]") ));
-            Assert.assertTrue("cutout2", dd.url.getQuery().contains( "cutout="+encodeString("[2]") ));
+            Assert.assertTrue("runID", dd.url.getQuery().contains("runid=testRunID"));
+            Assert.assertTrue("cutout", dd.url.getQuery().contains("cutout="+encodeString("[1]") ));
+            // TODO: should this support multiple cutout parameters?
+            //            Assert.assertTrue("cutout1", dd.url.getQuery().contains( "cutout="+encodeString("[1]") ));
+            //            Assert.assertTrue("cutout2", dd.url.getQuery().contains( "cutout="+encodeString("[2]") ));
             
         }
         catch(Exception unexpected)
@@ -164,7 +154,7 @@ public class AdDownloadGeneratorTest
         {
             AdDownloadGenerator gen = new AdDownloadGenerator();
             URI uri = new URI("foo", "SomeArchive/SomeFileID", null);
-            DownloadTuple dt = new DownloadTuple(uri, null, null);
+            DownloadTuple dt = new DownloadTuple(uri);
             Iterator<DownloadDescriptor> iter = gen.downloadIterator(dt);
             Assert.assertNotNull(iter);
             Assert.assertTrue(iter.hasNext());
@@ -191,19 +181,18 @@ public class AdDownloadGeneratorTest
         // & DownloadTuple as input
         try
         {
-            Map<String,List<String>> params = new HashMap<String,List<String>>();
-            List<String> ss = new ArrayList<String>();
-            ss.add("FOO");
-            params.put("logkey", ss);
-            ss = new ArrayList<String>();
-            ss.add("BAR");
-            params.put("logvalue", ss);
+//            Map<String,List<String>> params = new HashMap<String,List<String>>();
+//            List<String> ss = new ArrayList<String>();
+//            ss.add("FOO");
+//            params.put("logkey", ss);
+//            ss = new ArrayList<String>();
+//            ss.add("BAR");
+//            params.put("logvalue", ss);
 
             AdDownloadGenerator gen = new AdDownloadGenerator();
-            gen.setParameters(params);
 
             URI uri = new URI("ad", "SomeArchive/SomeFileID", null);
-            DownloadTuple dt = new DownloadTuple(uri, null, null);
+            DownloadTuple dt = new DownloadTuple(uri);
             Iterator<DownloadDescriptor> iter = gen.downloadIterator(dt);
 
             Assert.assertNotNull(iter);

--- a/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/handlers/AdDownloadGeneratorTest.java
+++ b/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/handlers/AdDownloadGeneratorTest.java
@@ -171,54 +171,7 @@ public class AdDownloadGeneratorTest
             Assert.fail("unexpected exception: " + unexpected);
         }
     }
-
-//    @Test
-    public void testLogKeyValue()
-    {
-        // This test is commented out until logkey/logvalue are determined
-        // to still be needed as input parameters - Sept, 2020
-        // Currently are pruned out during move to using DownloadRequest
-        // & DownloadTuple as input
-        try
-        {
-//            Map<String,List<String>> params = new HashMap<String,List<String>>();
-//            List<String> ss = new ArrayList<String>();
-//            ss.add("FOO");
-//            params.put("logkey", ss);
-//            ss = new ArrayList<String>();
-//            ss.add("BAR");
-//            params.put("logvalue", ss);
-
-            AdDownloadGenerator gen = new AdDownloadGenerator();
-
-            URI uri = new URI("ad", "SomeArchive/SomeFileID", null);
-            DownloadTuple dt = new DownloadTuple(uri);
-            Iterator<DownloadDescriptor> iter = gen.downloadIterator(dt);
-
-            Assert.assertNotNull(iter);
-            Assert.assertTrue(iter.hasNext());
-
-            DownloadDescriptor dd = iter.next();
-            Assert.assertEquals(DownloadDescriptor.OK, dd.status);
-
-            Assert.assertEquals("uri", uri.toASCIIString(), dd.uri);
-
-            Assert.assertEquals("protocol", baseURL.getProtocol(), dd.url.getProtocol());
-            Assert.assertEquals("hostname", baseURL.getHost(), dd.url.getHost());
-            Assert.assertEquals("path", baseURL.getPath() + "/SomeArchive/SomeFileID", dd.url.getPath());
-
-            Assert.assertNotNull("query", dd.url.getQuery());
-            Assert.assertTrue("logKey", dd.url.getQuery().contains("logkey=FOO"));
-            Assert.assertTrue("logValue", dd.url.getQuery().contains("logvalue=BAR"));
-
-        }
-        catch(Exception unexpected)
-        {
-            log.error("unexpected exception", unexpected);
-            Assert.fail("unexpected exception: " + unexpected);
-        }
-    }
-
+    
     private static String encodeString(String str)
     {
         try { return URLEncoder.encode(str, "UTF-8"); }


### PR DESCRIPTION
POS and CUTOUT supported. CUTOUT is a pass-through string that AdDownloadGenerator uses. POS is used by DataLinkClient.