### PR TITLE
CADC-8244 (CADC-1245 cutout story) - convert label strings to SODA-filename 

### DIFF
--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadGenerator.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadGenerator.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2011.                            (c) 2011.
+*  (c) 2020.                            (c) 2020.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -77,7 +77,7 @@ import java.util.Iterator;
 public interface DownloadGenerator {
     /**
      * Value used globally on all query strings
-     * @param runID
+     * @param runID Corresponding to search job this download request is from
      */
     public void setRunID(String runID);
 

--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTuple.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTuple.java
@@ -140,9 +140,7 @@ public class DownloadTuple {
         this.id = id;
         this.posCutout = cutout;
         this.pixelCutout = null;
-
-        DownloadTupleFormat df = new DownloadTupleFormat();
-        this.label = df.convertLabelText(label);
+        this.label = label;
     }
 
     /**
@@ -161,9 +159,7 @@ public class DownloadTuple {
         this.id = id;
         this.posCutout = null;
         this.pixelCutout = cutout;
-
-        DownloadTupleFormat df = new DownloadTupleFormat();
-        this.label = df.convertLabelText(label);
+        this.label = label;
     }
 
     public URI getID() {

--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTuple.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTuple.java
@@ -82,7 +82,7 @@ public class DownloadTuple {
 
     /**
      * ctor
-     * @param id
+     * @param id URI of download
      */
     public DownloadTuple(URI id) {
         if (id == null) {
@@ -96,8 +96,8 @@ public class DownloadTuple {
 
     /**
      * ctor
-     * @param id
-     * @param cutout
+     * @param id URI of download
+     * @param cutout (Optional) DALI Shape to be used for cutout
      */
     public DownloadTuple(URI id, Shape cutout) {
         if (id == null) {
@@ -111,8 +111,8 @@ public class DownloadTuple {
 
     /**
      * ctor
-     * @param id
-     * @param cutout
+     * @param id URI of download
+     * @param cutout (Optional) Pixel String to be used for cutout
      */
     public DownloadTuple(URI id, String cutout) {
         if (id == null) {
@@ -126,9 +126,9 @@ public class DownloadTuple {
 
     /**
      * ctor
-     * @param id
-     * @param cutout
-     * @param label
+     * @param id URI of download
+     * @param cutout (Optional) DALI Shape to be used for cutout
+     * @param label (Optional) sent as LABEL parameter to SODA calls
      */
     public DownloadTuple(URI id, Shape cutout, String label) {
         if (id == null) {
@@ -140,14 +140,16 @@ public class DownloadTuple {
         this.id = id;
         this.posCutout = cutout;
         this.pixelCutout = null;
-        this.label = label;
+
+        DownloadTupleFormat df = new DownloadTupleFormat();
+        this.label = df.convertLabelText(label);
     }
 
     /**
      * ctor
-     * @param id
-     * @param cutout
-     * @param label
+     * @param id URI of download
+     * @param cutout (Optional) DALI String to be used for cutout
+     * @param label (Optional) sent as LABEL parameter to SODA calls
      */
     public DownloadTuple(URI id, String cutout, String label) {
         if (id == null) {
@@ -159,7 +161,9 @@ public class DownloadTuple {
         this.id = id;
         this.posCutout = null;
         this.pixelCutout = cutout;
-        this.label = label;
+
+        DownloadTupleFormat df = new DownloadTupleFormat();
+        this.label = df.convertLabelText(label);
     }
 
     public URI getID() {

--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTupleFormat.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTupleFormat.java
@@ -123,7 +123,7 @@ public class DownloadTupleFormat {
                 // trim off trailing "}".
                 // guaranteed to be there due to
                 // check for equal occurrences of { and } above.
-                tmpLabel = l.substring(0, l.length() - 1);
+                tmpLabel = convertLabelText(l.substring(0, l.length() - 1));
             } else {
                 // invalid format
                 throw new DownloadTupleParsingException("invalid label format: " + tupleStr);

--- a/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleFormatTest.java
+++ b/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleFormatTest.java
@@ -68,6 +68,7 @@
 
 package ca.nrc.cadc.dlm;
 
+import ca.nrc.cadc.dali.Shape;
 import ca.nrc.cadc.util.Log4jInit;
 import java.net.URI;
 import org.apache.log4j.Logger;
@@ -145,6 +146,18 @@ public class DownloadTupleFormatTest extends DownloadTupleTestBase {
         Assert.assertEquals("ctor didn't work for id", dt.getID(), expectedURI);
         Assert.assertEquals("ctor didn't work for cutout", expectedCutout, dt.posCutout);
         Assert.assertEquals("ctor didn't work for label", expectedLabel, dt.label);
+    }
+
+    // Internal format string to DownloadTuple tests
+    @Test
+    public void testParseFullTupleLabelConverted() throws Exception {
+        DownloadTuple dt = df.parse("test://mysite.ca/path/1{circle 8.0 9.0 0.5}{02:24:07.5 +03:18:00 0.5}");
+        String exConvertedLabel = "02_24_07.5_p03_18_00_0.5";
+        Shape exCutout = sf.parse("circle 8.0 9.0 0.5");
+        URI exID = new URI("test://mysite.ca/path/1");
+        Assert.assertEquals("ctor didn't work for id", exID, dt.getID());
+        Assert.assertEquals("ctor didn't work for cutout", exCutout, dt.posCutout);
+        Assert.assertEquals("ctor didn't work for label", exConvertedLabel, dt.label);
     }
 
     @Test

--- a/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleFormatTest.java
+++ b/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleFormatTest.java
@@ -1,4 +1,3 @@
-
 /*
  ************************************************************************
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
@@ -69,8 +68,10 @@
 
 package ca.nrc.cadc.dlm;
 
+import ca.nrc.cadc.util.Log4jInit;
 import java.net.URI;
 import org.apache.log4j.Logger;
+import org.apache.log4j.Level;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -85,6 +86,11 @@ public class DownloadTupleFormatTest extends DownloadTupleTestBase {
 
     // test://mysite.ca/path/1{polygon 0 0 0 0 0 0}{label}
     private static String TUPLE_INTERNAL_FULL = TUPLE_INTERNAL_SHAPE + "{" + LABEL_STR + "}";
+
+
+    static {
+        Log4jInit.setLevel("ca.nrc.cadc", Level.INFO);
+    }
 
     @Before
     public void testSetup() {
@@ -290,6 +296,49 @@ public class DownloadTupleFormatTest extends DownloadTupleTestBase {
         } catch (Exception unexpected) {
             Assert.fail("unexpected error: " + unexpected);
         }
+    }
+
+    @Test
+    public void testValidLabelRadiusConversion() {
+        // Note: convertLabelText() doesn't throw errors, so there's nothing to test for
+        // invalid labels.
+
+        //        M101 30' --> M101_30arcmin
+        String label = "M101 30'";
+        String expectedConvertedLabel = "M101_30arcmin";
+        String actualConvertedLabel = "";
+        actualConvertedLabel = df.convertLabelText(label);
+        Assert.assertEquals("conversion failed", expectedConvertedLabel, actualConvertedLabel);
+
+        //        M101 45" --> M101_45arcsec
+        label = "M101 45\"";
+        expectedConvertedLabel = "M101_45arcsec";
+        actualConvertedLabel = df.convertLabelText(label);
+        Assert.assertEquals("conversion failed", expectedConvertedLabel, actualConvertedLabel);
+
+        //        HD79158 0.05 --> HD79158_0.05
+        label = "HD79158 0.05";
+        expectedConvertedLabel = "HD79158_0.05";
+        actualConvertedLabel = df.convertLabelText(label);
+        Assert.assertEquals("conversion failed", expectedConvertedLabel, actualConvertedLabel);
+
+        //        HD79158/2 0.05 --> HD79158_2_0.05
+        label = "HD79158/2 0.05";
+        expectedConvertedLabel = "HD79158_2_0.05";
+        actualConvertedLabel = df.convertLabelText(label);
+        Assert.assertEquals("conversion failed", expectedConvertedLabel, actualConvertedLabel);
+    }
+
+    @Test
+    public void testValidLabelTargetNameConversion() {
+        // Note: convertLabelText() doesn't throw errors, so there's no way to test for
+        // invalid labels.
+
+        //        02:24:07.5 +03:18:00 0.5 --> 02:24:07.5_03:18:00_0.5
+        String label = "02:24:07.5 +03:18:00 0.5";
+        String expectedConvertedLabel = "02_24_07.5_p03_18_00_0.5";
+        String actualConvertedLabel = df.convertLabelText(label);
+        Assert.assertEquals("conversion failed", expectedConvertedLabel, actualConvertedLabel);
     }
 
 }

--- a/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleTest.java
+++ b/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleTest.java
@@ -81,7 +81,7 @@ public class DownloadTupleTest extends DownloadTupleTestBase {
     private static Logger log = Logger.getLogger(DownloadTupleTest.class);
 
     static {
-        Log4jInit.setLevel("ca.nrc.cadc", Level.DEBUG);
+        Log4jInit.setLevel("ca.nrc.cadc", Level.INFO);
     }
 
     @Before


### PR DESCRIPTION
                  // Translate the special characters in this string to what will
                  // be used in the SODA calls in downloadManager.
                  // Rules from user story CADC-1245, subtask CADC 8244
                  // '/' added because SODA service (caom2ops) does not accept it.
                  // 1) ' -> arcmin
                  // 2) " -> arcsec
                  // 3) '+' -> 'p'
                  // 4) ':' and '/' -> '_'
                  // 5) all whitespaces replaced by underscores.