### PR TITLE
CADC-8561: add BAND parameter to downloadManager API

### DIFF
--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTuple.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTuple.java
@@ -68,17 +68,20 @@
 
 package ca.nrc.cadc.dlm;
 
+import ca.nrc.cadc.dali.DoubleInterval;
 import ca.nrc.cadc.dali.Shape;
 import java.net.URI;
-import org.apache.log4j.Logger;
 
 public class DownloadTuple {
-    private static Logger log = Logger.getLogger(DownloadTuple.class);
 
+    // Only value that is required is the id.
     private final URI id;
-    public final Shape posCutout;
-    public final String pixelCutout;
-    public final String label;
+
+    // These values can all be null
+    public Shape posCutout;
+    public DoubleInterval bandCutout;
+    public String pixelCutout;
+    public String label;
 
     /**
      * ctor
@@ -90,6 +93,7 @@ public class DownloadTuple {
         }
         this.id = id;
         this.posCutout = null;
+        this.bandCutout = null;
         this.pixelCutout = null;
         this.label = null;
     }
@@ -97,68 +101,22 @@ public class DownloadTuple {
     /**
      * ctor
      * @param id URI of download
-     * @param cutout (Optional) DALI Shape to be used for cutout
-     */
-    public DownloadTuple(URI id, Shape cutout) {
-        if (id == null) {
-            throw new IllegalArgumentException("id can not be null");
-        }
-        this.id = id;
-        this.posCutout = cutout;
-        this.pixelCutout = null;
-        this.label = null;
-    }
-
-    /**
-     * ctor
-     * @param id URI of download
-     * @param cutout (Optional) Pixel String to be used for cutout
-     */
-    public DownloadTuple(URI id, String cutout) {
-        if (id == null) {
-            throw new IllegalArgumentException("id can not be null");
-        }
-        this.id = id;
-        this.posCutout = null;
-        this.pixelCutout = cutout;
-        this.label = null;
-    }
-
-    /**
-     * ctor
-     * @param id URI of download
-     * @param cutout (Optional) DALI Shape to be used for cutout
+     * @param posCutout (Optional) DALI Shape to be used for position cutout (POS parameter)
+     * @param bandCutout (Optional) DoubleInterval to be used for band cutout (BAND parameter)
+     * @param pixelCutout (Optional) String to be used for pixel cutout (passed through without validation)
      * @param label (Optional) sent as LABEL parameter to SODA calls
      */
-    public DownloadTuple(URI id, Shape cutout, String label) {
+    public DownloadTuple(URI id, Shape posCutout, DoubleInterval bandCutout, String pixelCutout, String label) {
         if (id == null) {
             throw new IllegalArgumentException("id can not be null");
         }
-        if (label != null && cutout == null) {
+        if (label != null && posCutout == null) {
             throw new IllegalArgumentException("cutout can not be null if label is defined.");
         }
         this.id = id;
-        this.posCutout = cutout;
-        this.pixelCutout = null;
-        this.label = label;
-    }
-
-    /**
-     * ctor
-     * @param id URI of download
-     * @param cutout (Optional) DALI String to be used for cutout
-     * @param label (Optional) sent as LABEL parameter to SODA calls
-     */
-    public DownloadTuple(URI id, String cutout, String label) {
-        if (id == null) {
-            throw new IllegalArgumentException("id can not be null");
-        }
-        if (label != null && cutout == null) {
-            throw new IllegalArgumentException("cutout can not be null if label is defined.");
-        }
-        this.id = id;
-        this.posCutout = null;
-        this.pixelCutout = cutout;
+        this.posCutout = posCutout;
+        this.bandCutout = bandCutout;
+        this.pixelCutout = pixelCutout;
         this.label = label;
     }
 

--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTupleFormat.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTupleFormat.java
@@ -122,7 +122,7 @@ public class DownloadTupleFormat {
             try {
                 tmpURI = new URI(uriStr);
             } catch (URISyntaxException u) {
-                throw new DownloadTupleParsingException("id parsing error: " + u + ": " + tupleStr);
+                throw new DownloadTupleParsingException("id parsing error: " + tupleStr, u);
             }
         } else {
             // invalid format - has to at least be a single URI passed in
@@ -134,7 +134,7 @@ public class DownloadTupleFormat {
 
         if (openBraceCount == 3) {
             String tmpPosStr = tupleParts[1];
-            if (tmpPosStr.length() > 1) {
+            if (StringUtil.hasLength(tmpPosStr)) {
                 // trim off trailing "}"
                 String tmpShapeStr = tmpPosStr.substring(0, tmpPosStr.length() - 1);
                 log.debug("cutout string: " + tmpShapeStr);
@@ -145,16 +145,16 @@ public class DownloadTupleFormat {
                         log.debug("parsed cutout.");
                     } catch (IllegalArgumentException ill) {
                         log.debug("parsing error for cutout: " + tmpShapeStr);
-                        throw new DownloadTupleParsingException("pos cutout parsing error: " + ill + ": " + tmpPosStr);
+                        throw new DownloadTupleParsingException("pos cutout parsing error: " + tmpPosStr, ill);
                     } catch (Exception e) {
-                        log.debug("other error for parsing pos cutout:" + e);
-                        throw new DownloadTupleParsingException("BUG for pos cutout:" + e + ": " + tmpPosStr);
+                        log.debug("other error for parsing pos cutout:", e);
+                        throw new DownloadTupleParsingException("BUG for pos cutout:" + e + ": " + tmpPosStr, e);
                     }
                 }
             }
 
             String tmpBandStr = tupleParts[2];
-            if (tmpBandStr.length() > 1) {
+            if (StringUtil.hasLength(tmpBandStr)) {
                 // trim off trailing "}"
                 String tmpShapeStr = tmpBandStr.substring(0, tmpBandStr.length() - 1);
                 log.debug("cutout string: " + tmpShapeStr);
@@ -164,11 +164,11 @@ public class DownloadTupleFormat {
                         newTuple.bandCutout = dif.parse(tmpShapeStr);
                         log.debug("parsed band cutout.");
                     } catch (IllegalArgumentException ill) {
-                        log.debug("parsing error for band cutout: " + tmpBandStr);
-                        throw new DownloadTupleParsingException("band cutout parsing error: " + ill + ": " + tmpBandStr);
+                        log.debug("parsing error for band cutout: " + tmpBandStr, ill);
+                        throw new DownloadTupleParsingException("band cutout parsing error: " + tmpBandStr, ill);
                     } catch (Exception e) {
-                        log.debug("other error for parsing band cutout:" + e);
-                        throw new DownloadTupleParsingException("BUG for band cutout:" + e + ": " + tmpBandStr);
+                        log.debug("other error for parsing band cutout:", e);
+                        throw new DownloadTupleParsingException("BUG for band cutout:" + tmpBandStr, e);
                     }
                 }
             }
@@ -283,7 +283,7 @@ public class DownloadTupleFormat {
             newTuple.pixelCutout = pixelCutoutStr;
             return newTuple;
         } catch (URISyntaxException uriEx)  {
-            throw new DownloadTupleParsingException("invalid id for tuple:" + uriEx);
+            throw new DownloadTupleParsingException("invalid id for tuple:", uriEx);
         }
     }
 
@@ -300,7 +300,7 @@ public class DownloadTupleFormat {
                 DoubleInterval bandCutout = dif.parse(bandCutoutStr);
                 return bandCutout;
             } catch (IllegalArgumentException argEx) {
-                throw new DownloadTupleParsingException("invalid band cutout:" + bandCutoutStr);
+                throw new DownloadTupleParsingException("invalid band cutout:" + bandCutoutStr, argEx);
             }
         }
         return null;
@@ -319,7 +319,7 @@ public class DownloadTupleFormat {
                 Shape posCutout = sf.parse(posCutoutStr);
                 return posCutout;
             } catch (IllegalArgumentException argEx)  {
-                throw new DownloadTupleParsingException("invalid pos cutout:" + posCutoutStr);
+                throw new DownloadTupleParsingException("invalid pos cutout:" + posCutoutStr, argEx);
             }
         }
         return null;

--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTupleFormat.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadTupleFormat.java
@@ -68,7 +68,9 @@
 
 package ca.nrc.cadc.dlm;
 
+import ca.nrc.cadc.dali.DoubleInterval;
 import ca.nrc.cadc.dali.Shape;
+import ca.nrc.cadc.dali.util.DoubleIntervalFormat;
 import ca.nrc.cadc.dali.util.ShapeFormat;
 import ca.nrc.cadc.util.StringUtil;
 import java.net.URI;
@@ -90,6 +92,10 @@ public class DownloadTupleFormat {
      */
     public DownloadTuple parse(String tupleStr) throws DownloadTupleParsingException {
         log.debug("tuple string input: " + tupleStr);
+        // format is either:
+        // uri (no braces)
+        // uri{optional position string}{optional band string}{optional label string}
+
         // Do a rough match of number of '{' to '}'
         // This doesn't check for order or overall format
         int openBraceCount = getCount(tupleStr, "\\{");
@@ -101,67 +107,13 @@ public class DownloadTupleFormat {
             throw new DownloadTupleParsingException("invalid tuple format: mismatched braces ': " + tupleStr);
         }
 
-        if (openBraceCount > 2) {
-            throw new DownloadTupleParsingException("invalid tuple format: too many braces ': " + tupleStr);
+        // either all or nothing
+        if (openBraceCount != 0 && openBraceCount != 3) {
+            throw new DownloadTupleParsingException("invalid tuple format: " + tupleStr);
         }
 
         // Split out the tuple parts
-        String [] tupleParts = tupleStr.split("\\{");
-        String tmpLabel;
-
-        if (tupleParts.length > 3) {
-            throw new DownloadTupleParsingException("tuple has too many parts. expected max 3 and found "
-                + tupleParts.length + ": " + tupleStr);
-        }
-        log.debug("tuple parts count: " + tupleParts.length);
-
-        // Get any label that might be there
-        if (tupleParts.length == 3) {
-            // grab optional third [2] parameter as label
-            String l = tupleParts[2];
-            if (l.length() > 1) {
-                // trim off trailing "}".
-                // guaranteed to be there due to
-                // check for equal occurrences of { and } above.
-                tmpLabel = convertLabelText(l.substring(0, l.length() - 1));
-            } else {
-                // invalid format
-                throw new DownloadTupleParsingException("invalid label format: " + tupleStr);
-            }
-        } else {
-            tmpLabel = null;
-        }
-
-        // Get any cutout that might be there
-        Shape tmpShape = null;
-        if (tupleParts.length > 1) {
-            String sd = tupleParts[1];
-            if (sd.length() > 1) {
-                // trim off trailing "}"
-                // guaranteed to be there due to
-                // check for equal occurrences of { and } above.
-                String tmpShapeStr = sd.substring(0, sd.length() - 1);
-                // put off parsing until id is parsed
-                log.debug("cutout string: " + tmpShapeStr);
-                if (StringUtil.hasLength(tmpShapeStr)) {
-                    try {
-                        ShapeFormat sf = new ShapeFormat();
-                        tmpShape = sf.parse(tmpShapeStr);
-                        log.debug("parsed cutout.");
-                    } catch (IllegalArgumentException ill) {
-                        log.debug("parsing error for cutout: " + tmpShapeStr);
-                        throw new DownloadTupleParsingException("cutout parsing error: " + ill + ": " + tupleStr);
-                    } catch (Exception e) {
-                        log.debug("other error for parsing cutout:" + e);
-                        throw new DownloadTupleParsingException("BUG for cutout:" + e + ": " + tupleStr);
-                    }
-                }
-            } else {
-                // invalid format
-                throw new DownloadTupleParsingException("invalid cutout: " + tupleStr);
-            }
-        }
-
+        String[] tupleParts = tupleStr.split("\\{");
         // Get tuple URI - should at least have this.
         URI tmpURI = null;
         String uriStr = tupleParts[0];
@@ -176,8 +128,67 @@ public class DownloadTupleFormat {
             // invalid format - has to at least be a single URI passed in
             throw new DownloadTupleParsingException("zero length id found: " + tupleStr);
         }
-        
-        return new DownloadTuple(tmpURI, tmpShape, tmpLabel);
+
+        // Create new DownloadTuple
+        DownloadTuple newTuple = new DownloadTuple(tmpURI);
+
+        if (openBraceCount == 3) {
+            String tmpPosStr = tupleParts[1];
+            if (tmpPosStr.length() > 1) {
+                // trim off trailing "}"
+                String tmpShapeStr = tmpPosStr.substring(0, tmpPosStr.length() - 1);
+                log.debug("cutout string: " + tmpShapeStr);
+                if (StringUtil.hasLength(tmpShapeStr)) {
+                    try {
+                        ShapeFormat sf = new ShapeFormat();
+                        newTuple.posCutout = sf.parse(tmpShapeStr);
+                        log.debug("parsed cutout.");
+                    } catch (IllegalArgumentException ill) {
+                        log.debug("parsing error for cutout: " + tmpShapeStr);
+                        throw new DownloadTupleParsingException("pos cutout parsing error: " + ill + ": " + tmpPosStr);
+                    } catch (Exception e) {
+                        log.debug("other error for parsing pos cutout:" + e);
+                        throw new DownloadTupleParsingException("BUG for pos cutout:" + e + ": " + tmpPosStr);
+                    }
+                }
+            }
+
+            String tmpBandStr = tupleParts[2];
+            if (tmpBandStr.length() > 1) {
+                // trim off trailing "}"
+                String tmpShapeStr = tmpBandStr.substring(0, tmpBandStr.length() - 1);
+                log.debug("cutout string: " + tmpShapeStr);
+                if (StringUtil.hasLength(tmpShapeStr)) {
+                    try {
+                        DoubleIntervalFormat dif = new DoubleIntervalFormat();
+                        newTuple.bandCutout = dif.parse(tmpShapeStr);
+                        log.debug("parsed band cutout.");
+                    } catch (IllegalArgumentException ill) {
+                        log.debug("parsing error for band cutout: " + tmpBandStr);
+                        throw new DownloadTupleParsingException("band cutout parsing error: " + ill + ": " + tmpBandStr);
+                    } catch (Exception e) {
+                        log.debug("other error for parsing band cutout:" + e);
+                        throw new DownloadTupleParsingException("BUG for band cutout:" + e + ": " + tmpBandStr);
+                    }
+                }
+            }
+
+            // grab optional third [2] parameter as label
+            String l = tupleParts[3];
+            if (l.length() > 1) {
+                if (newTuple.posCutout == null) {
+                    throw new DownloadTupleParsingException("no cutout defined with label");
+                }
+                // trim off trailing "}".
+                String tmpLabel = l.substring(0, l.length() - 1);
+                if (StringUtil.hasLength(tmpLabel)) {
+                    newTuple.label = convertLabelText(tmpLabel);
+                }
+
+            }
+        }
+
+        return newTuple;
     }
 
     private int getCount(final String input, final String regexp) {
@@ -198,18 +209,26 @@ public class DownloadTupleFormat {
      * @return string representation of tuple
      */
     public String format(DownloadTuple tuple) {
-        String tupleStr = tuple.getID().toString();
+        StringBuilder sb = new StringBuilder();
+        sb.append(tuple.getID().toString());
 
+        sb.append("{");
         if (tuple.posCutout != null) {
             ShapeFormat sf = new ShapeFormat();
-            tupleStr += "{" + sf.format(tuple.posCutout) + "}";
+            sb.append(sf.format(tuple.posCutout));
         }
-
+        sb.append("}{");
+        if (tuple.bandCutout != null) {
+            DoubleIntervalFormat dif = new DoubleIntervalFormat();
+            sb.append(dif.format(tuple.bandCutout));
+        }
+        sb.append("}{");
         if (StringUtil.hasLength(tuple.label)) {
-            tupleStr += "{" + tuple.label + "}";
+            sb.append(tuple.label);
         }
+        sb.append("}");
 
-        return tupleStr;
+        return sb.toString();
     }
 
     /**
@@ -217,39 +236,94 @@ public class DownloadTupleFormat {
      * Note: this code can be used at the tail end of parsing JSON input, or other blob-type data
      * that is provided in String format. Use this function to leverage the validation code found
      * in parse(internal_format_string).
-     * @param part1 string representation of URI for download
-     * @param part2 (Optional) DALI string representation of cutout
-     * @param part3 (Optional) label to add to download request
+     * @param uriStr string representation of URI for download
+     * @param posCutoutStr (Optional) DALI string representation of cutout
+     * @param bandCutoutStr (Optional) label to add to download request
+     * @param labelStr (Optional) label to add to download request
      * @return DownloadTuple populated with tuple information provided.
      * @throws DownloadTupleParsingException if tuple is malformed or content is invalid
      */
-    public DownloadTuple parseUsingInternalFormat(String part1, String part2, String part3) throws DownloadTupleParsingException {
-        String tupleStr = part1;
-        if (StringUtil.hasLength(part2)) {
-            tupleStr += "{" + part2 + "}";
+    public DownloadTuple parseUsingInternalFormat(String uriStr, String posCutoutStr,
+                                                  String bandCutoutStr, String labelStr)
+        throws DownloadTupleParsingException {
+        // build up a full tuple of format:
+        // URI{pos DALI string}{band DALI string}{SODA filename label}
+        // where only the URI is required
+        // ie: uri{}{}{} is a possible output
+        StringBuilder sb = new StringBuilder();
+        sb.append(uriStr);
+        sb.append("{");
+
+        if (StringUtil.hasLength(posCutoutStr)) {
+            sb.append(posCutoutStr);
         }
-        if (StringUtil.hasLength(part3)) {
-            tupleStr += "{" + part3 + "}";
+        sb.append("}{");
+        if (StringUtil.hasLength(bandCutoutStr)) {
+            sb.append(bandCutoutStr);
         }
-        return parse(tupleStr);
+        sb.append("}{");
+        if (StringUtil.hasLength(labelStr)) {
+            sb.append(labelStr);
+        }
+        sb.append("}");
+        return parse(sb.toString());
     }
 
     /**
      * Create a DownloadTuple using a URI string and a cutout string.
      * @param uriStr URI for download
-     * @param cutoutStr pixel cutout to apply to download
-     * @return DownloadTuple popuplated with URI and cutout.
+     * @param pixelCutoutStr pixel cutout to apply to download
+     * @return DownloadTuple populated with URI and cutout.
      * @throws DownloadTupleParsingException if URI is invalid
      */
-    public DownloadTuple parsePixelStringTuple(String uriStr, String cutoutStr) throws DownloadTupleParsingException  {
+    public DownloadTuple parsePixelStringTuple(String uriStr, String pixelCutoutStr) throws DownloadTupleParsingException  {
         try {
             URI tmpURI = new URI(uriStr);
-            return new DownloadTuple(tmpURI, cutoutStr);
+            DownloadTuple newTuple = new DownloadTuple(tmpURI);
+            newTuple.pixelCutout = pixelCutoutStr;
+            return newTuple;
         } catch (URISyntaxException uriEx)  {
             throw new DownloadTupleParsingException("invalid id for tuple:" + uriEx);
         }
     }
 
+    /**
+     * Validate a band (interval) cutout string. To be used in setting DownloadTuple bandCutout.
+     * @param bandCutoutStr DALI DoubleInterval string
+     * @return DoubleInterval populated with doubles from input string
+     * @throws DownloadTupleParsingException if DoubleInterval is invalid
+     */
+    public DoubleInterval parseBandCutout(String bandCutoutStr) throws DownloadTupleParsingException  {
+        if (StringUtil.hasLength(bandCutoutStr)) {
+            try {
+                DoubleIntervalFormat dif = new DoubleIntervalFormat();
+                DoubleInterval bandCutout = dif.parse(bandCutoutStr);
+                return bandCutout;
+            } catch (IllegalArgumentException argEx) {
+                throw new DownloadTupleParsingException("invalid band cutout:" + bandCutoutStr);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Validate a position cutout string. To be used in setting DownloadTuple posCutout.
+     * @param posCutoutStr DALI Shape string
+     * @return Shape populated with values from input string
+     * @throws DownloadTupleParsingException if Shape is invalid
+     */
+    public Shape parsePosCutout(String posCutoutStr) throws DownloadTupleParsingException  {
+        if (StringUtil.hasLength(posCutoutStr)) {
+            try {
+                ShapeFormat sf = new ShapeFormat();
+                Shape posCutout = sf.parse(posCutoutStr);
+                return posCutout;
+            } catch (IllegalArgumentException argEx)  {
+                throw new DownloadTupleParsingException("invalid pos cutout:" + posCutoutStr);
+            }
+        }
+        return null;
+    }
 
     /**
      * Convert a string to a format that can be used for subsequent web service calls.

--- a/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadUtil.java
+++ b/cadc-download-manager/src/main/java/ca/nrc/cadc/dlm/DownloadUtil.java
@@ -69,6 +69,7 @@
 
 package ca.nrc.cadc.dlm;
 
+import ca.nrc.cadc.util.ArgumentMap;
 import ca.nrc.cadc.util.CaseInsensitiveStringComparator;
 import ca.nrc.cadc.util.StringUtil;
 
@@ -83,6 +84,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.TreeMap;
 
+import java.util.TreeSet;
 import org.apache.log4j.Logger;
 
 /**
@@ -232,5 +234,7 @@ public class DownloadUtil {
             }
         };
     }
+
+
 
 }

--- a/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleComparatorTest.java
+++ b/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleComparatorTest.java
@@ -101,19 +101,22 @@ public class DownloadTupleComparatorTest {
 
     @Before
     public void beforeTest() throws Exception {
-        d1 = new DownloadTuple(new URI("test://uri/1"), sf.parse(circleShape), "circleLabel");
-        d2 = new DownloadTuple(new URI("test://uri/2"), sf.parse(circleShape2), "circleLabel2");
-        d3 = new DownloadTuple(new URI("test://uri/3"), sf.parse(polygonShape), "polygonLabel");
+        d1 = new DownloadTuple(new URI("test://uri/1"), sf.parse(circleShape), null, null, "circleLabel");
+        d2 = new DownloadTuple(new URI("test://uri/2"), sf.parse(circleShape2),null, null,  "circleLabel2");
+        d3 = new DownloadTuple(new URI("test://uri/3"), sf.parse(polygonShape),null, null,  "polygonLabel");
 
         d4 = new DownloadTuple(new URI("test://uri/1"));
-        d5 = new DownloadTuple(new URI("test://uri/2"), sf.parse(circleShape2), null);
+        d5 = new DownloadTuple(new URI("test://uri/2"), sf.parse(circleShape2), null, null, null);
     }
 
     @Test
     public void testDuplicates() throws Exception {
         // Add a duplicate, size of TreeSet should be one less than number of tuples
         testTreeSet = new TreeSet(new DownloadTupleComparator());
-        DownloadTuple dup = new DownloadTuple(new URI("test://uri/1"), sf.parse(circleShape), "circleLabel");
+        DownloadTuple dup = new DownloadTuple(new URI("test://uri/1"));
+        dup.posCutout = sf.parse(circleShape);
+        dup.label = "circleLabel";
+
         testTreeSet.add(d1);
         testTreeSet.add(d2);
         testTreeSet.add(dup);

--- a/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleTest.java
+++ b/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleTest.java
@@ -69,6 +69,9 @@
 
 package ca.nrc.cadc.dlm;
 
+import ca.nrc.cadc.dali.DoubleInterval;
+import ca.nrc.cadc.dali.Shape;
+import ca.nrc.cadc.dali.util.DoubleIntervalFormat;
 import ca.nrc.cadc.util.Log4jInit;
 import java.net.URI;
 import org.apache.log4j.Level;
@@ -88,8 +91,6 @@ public class DownloadTupleTest extends DownloadTupleTestBase {
     public void testSetup() {
         try {
             expectedURI = new URI(URI_STR);
-            expectedCutout = sf.parse(SHAPE_STR);
-            expectedLabel = LABEL_STR;
         } catch (Exception unexpectedSetupError) {
             log.error("DownalodTupleTest setup failed: " + unexpectedSetupError);
             Assert.fail("test setup failed.");
@@ -100,43 +101,42 @@ public class DownloadTupleTest extends DownloadTupleTestBase {
     public void testURIOnly() throws Exception {
         DownloadTuple dt = new DownloadTuple(new URI(URI_STR));
         log.debug("uri only: " + dt.getID());
-        Assert.assertEquals("ctor didn't work", dt.getID(),expectedURI);
+        Assert.assertEquals("ctor for URI didn't work", dt.getID(),expectedURI);
     }
 
     @Test
-    public void testURIShape() throws Exception {
-        DownloadTuple dt = new DownloadTuple(new URI(URI_STR), sf.parse(SHAPE_STR), null);
+    public void testFull() throws Exception {
+        String bandCutoutStr = "1.0 2.0";
+        DoubleIntervalFormat dif = new DoubleIntervalFormat();
+        DoubleInterval bandCutout = dif.parse(bandCutoutStr);
+        Shape posCutout = sf.parse(SHAPE_STR);
+        String pixelCutout = "[5]";
+
+        DownloadTuple dt = new DownloadTuple(new URI(URI_STR), posCutout, bandCutout, pixelCutout, "testLabel");
         Assert.assertEquals("ctor didn't work for id", dt.getID(), expectedURI);
-        Assert.assertEquals("ctor didn't work for posCutout", expectedCutout, dt.posCutout );
-        Assert.assertEquals("ctor didn't work for pixelCutout", null, dt.pixelCutout );
+        Assert.assertEquals("ctor didn't work for posCutout", posCutout, dt.posCutout );
+        Assert.assertEquals("ctor didn't work for bandCutout", bandCutout, dt.bandCutout );
+        Assert.assertEquals("ctor didn't work for pixelCutout", pixelCutout, dt.pixelCutout );
+        Assert.assertEquals("ctor didn't work for label", "testLabel", dt.label );
     }
 
     @Test
-    public void testShapeCutoutTuple() throws Exception {
-        DownloadTuple dt = new DownloadTuple(new URI(URI_STR), sf.parse(SHAPE_STR), LABEL_STR);
-        Assert.assertEquals("ctor didn't work for id", expectedURI, dt.getID());
-        Assert.assertEquals("ctor didn't work for cutout", expectedCutout, dt.posCutout );
-        Assert.assertEquals("ctor didn't work for label", expectedLabel, dt.label);
-    }
-
-    // Valid tests only for pixelCutout as it is not validated
-    @Test
-    public void testPixelCutoutFullTuple() throws Exception {
-        String expectedPixelCutout = "[2]";
-        DownloadTuple dt = new DownloadTuple(new URI(URI_STR), "[2]", LABEL_STR);
-        Assert.assertEquals("ctor didn't work for id", expectedURI, dt.getID());
-        Assert.assertEquals("ctor didn't work for posCutout", null, dt.posCutout );
-        Assert.assertEquals("ctor didn't work for pixelCutout", expectedPixelCutout, dt.pixelCutout );
-        Assert.assertEquals("ctor didn't work for label", expectedLabel, dt.label);
+    public void testInvalidLabelNoShape() throws Exception {
+        try {
+            DownloadTuple dt = new DownloadTuple(new URI(URI_STR), null, null, null, "testLabel");
+            Assert.fail("ctor should have failed");
+        } catch (IllegalArgumentException expected) {
+            log.info("expected parsing error: " + expected);
+        }
     }
 
     @Test
-    public void testPixelCutoutTuple() throws Exception {
-        String expectedPixelCutout = "[2]";
-        DownloadTuple dt = new DownloadTuple(new URI(URI_STR), "[2]");
-        Assert.assertEquals("ctor didn't work for id", expectedURI, dt.getID());
-        Assert.assertEquals("ctor didn't work for posCutout", null, dt.posCutout );
-        Assert.assertEquals("ctor didn't work for pixelCutout", expectedPixelCutout, dt.pixelCutout );
-        Assert.assertEquals("ctor didn't work for label", null, dt.label);
+    public void testInvalidNoURI() throws Exception {
+        try {
+            DownloadTuple dt = new DownloadTuple(null, sf.parse(SHAPE_STR), null, null, "testLabel");
+            Assert.fail("ctor should have failed");
+        } catch (IllegalArgumentException expected) {
+            log.info("expected parsing error: " + expected);
+        }
     }
 }

--- a/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleTestBase.java
+++ b/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/DownloadTupleTestBase.java
@@ -68,7 +68,9 @@
 
 package ca.nrc.cadc.dlm;
 
+import ca.nrc.cadc.dali.DoubleInterval;
 import ca.nrc.cadc.dali.Shape;
+import ca.nrc.cadc.dali.util.DoubleIntervalFormat;
 import ca.nrc.cadc.dali.util.ShapeFormat;
 import ca.nrc.cadc.util.Log4jInit;
 import java.net.URI;
@@ -82,15 +84,19 @@ public abstract class DownloadTupleTestBase {
     // Knowing this doesn't make sense as a polygon, it adheres to the format needed
     // by cadc-dali PolygonFormat
     protected static String SHAPE_STR = "polygon 0.0 0.0 0.0 0.0 0.0 0.0";
+    protected static String BAND_CUTOUT_STR = "2.0 3.0";
     protected static String LABEL_STR = "label";
+    protected DownloadTupleFormat df = new DownloadTupleFormat();
+    protected DoubleIntervalFormat dif = new DoubleIntervalFormat();
     protected ShapeFormat sf = new ShapeFormat();
 
     protected URI expectedURI;
     protected Shape expectedCutout;
+    protected DoubleInterval expectedIntervalCutout;
     protected String expectedLabel;
 
     static {
-        Log4jInit.setLevel("ca.nrc.cadc", Level.DEBUG);
+        Log4jInit.setLevel("ca.nrc.cadc", Level.INFO);
     }
 
     @Before

--- a/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/handlers/AdDownloadGeneratorTest.java
+++ b/cadc-download-manager/src/test/java/ca/nrc/cadc/dlm/handlers/AdDownloadGeneratorTest.java
@@ -116,7 +116,8 @@ public class AdDownloadGeneratorTest
             gen.setRunID("testRunID");
 
             URI uri = new URI("ad", "SomeArchive/SomeFileID", null);
-            DownloadTuple dt = new DownloadTuple(uri, "[1]");
+            DownloadTuple dt = new DownloadTuple(uri);
+            dt.pixelCutout = "[1]";
             Iterator<DownloadDescriptor> iter = gen.downloadIterator(dt);
 
             Assert.assertNotNull(iter);


### PR DESCRIPTION
Reinstates ability to do spectral cutouts in SODA calls (using DataLinkClient.java in cadc-download-manager.)

Testing:
- downloadManager web service integration tests ran successfully

Manually tested from AdvancedSearch with the following scenarios:
- target upload file + spatial cutout request
- single target + spatial and/or spectral request
- target upload & single target with no cutout requests

not covered:
- target upload file + spectral cutout request (
