### PR TITLE
CADC-9742: updates so downloadManager works against arc

### DIFF
--- a/cadc-download-manager-server/build.gradle
+++ b/cadc-download-manager-server/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenLocal()
 }
 
-version = '1.3.0'
+version = '1.3.1'
 group = 'org.opencadc'
 sourceCompatibility = 1.8
 
@@ -26,7 +26,7 @@ dependencies {
     compile 'org.opencadc:cadc-util:[1.0,)'
     compile 'org.opencadc:cadc-log:[1.0,)'
     compile 'org.opencadc:cadc-registry:[1.0,)'
-    compile 'org.opencadc:cadc-rest:[1.2.15,)'
+    compile 'org.opencadc:cadc-rest:[1.3.3,)'
     compile 'org.opencadc:cadc-app-kit:[1.0,)'
     compile 'org.opencadc:cadc-download-manager:[1.4.0,)'
     compile 'org.opencadc:cadc-web-util:[1.2.7,)'

--- a/cadc-download-manager-server/src/main/java/ca/nrc/cadc/dlm/server/DLMInputHandler.java
+++ b/cadc-download-manager-server/src/main/java/ca/nrc/cadc/dlm/server/DLMInputHandler.java
@@ -75,6 +75,8 @@ import ca.nrc.cadc.dlm.DownloadTupleFormat;
 import ca.nrc.cadc.dlm.DownloadTupleParsingException;
 import ca.nrc.cadc.dlm.DownloadUtil;
 import ca.nrc.cadc.net.ResourceNotFoundException;
+import ca.nrc.cadc.net.TransientException;
+
 import ca.nrc.cadc.rest.SyncInput;
 import ca.nrc.cadc.util.StringUtil;
 import java.io.IOException;
@@ -131,7 +133,7 @@ public class DLMInputHandler {
         try {
             si = new SyncInput(servletRequest, new DLMInlineContentHandler());
             si.init();
-        } catch (IOException | ResourceNotFoundException ioe) {
+        } catch (IOException | ResourceNotFoundException | TransientException ioe) {
             // TODO: make this more sanely split out & informative
             throw new DLMParsingException("couldn't parse request");
         }


### PR DESCRIPTION
- this includes the latest version of cadc-rest that made SyncInput.java public again. 

Also for review: branch cadc99742 of wwebui/downloadManager, the version of DLM that uses this cadc-download-manager-server library version. 