### PR TITLE
CADC-9742: getting DLM to work against arc

### DIFF
--- a/cadc-download-manager-server/build.gradle
+++ b/cadc-download-manager-server/build.gradle
@@ -34,8 +34,6 @@ dependencies {
 
     testCompile 'junit:junit:4.13'
     testCompile 'org.easymock:easymock:3.6'
-
-    runtime 'org.opencadc:cadc-access-control-identity:[1.1.0,)'
 }
 
 apply from: '../opencadc.gradle'

--- a/cadc-download-manager-server/build.gradle
+++ b/cadc-download-manager-server/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenLocal()
 }
 
-version = '1.3.1'
+version = '1.3.2'
 group = 'org.opencadc'
 sourceCompatibility = 1.8
 
@@ -23,17 +23,19 @@ dependencies {
     compile 'log4j:log4j:[1.2,)'
     compile 'javax.servlet:javax.servlet-api:[3.1,)'
 
-    compile 'org.opencadc:cadc-util:[1.0,)'
+    compile 'org.opencadc:cadc-util:[1.4.2,)'
     compile 'org.opencadc:cadc-log:[1.0,)'
     compile 'org.opencadc:cadc-registry:[1.0,)'
     compile 'org.opencadc:cadc-rest:[1.3.3,)'
     compile 'org.opencadc:cadc-app-kit:[1.0,)'
-    compile 'org.opencadc:cadc-download-manager:[1.4.0,)'
-    compile 'org.opencadc:cadc-web-util:[1.2.7,)'
+    compile 'org.opencadc:cadc-download-manager:[1.4.2,)'
+    compile 'org.opencadc:cadc-web-util:[1.2.10,)'
     compile 'commons-io:commons-io:[2.7,)'
 
     testCompile 'junit:junit:4.13'
     testCompile 'org.easymock:easymock:3.6'
+
+    runtime 'org.opencadc:cadc-access-control-identity:[1.1.0,)'
 }
 
 apply from: '../opencadc.gradle'

--- a/cadc-download-manager/build.gradle
+++ b/cadc-download-manager/build.gradle
@@ -11,7 +11,7 @@ repositories {
     mavenLocal()
 }
 
-version = '1.4.1'
+version = '1.4.2'
 group = 'org.opencadc'
 sourceCompatibility = 1.8
 
@@ -23,7 +23,7 @@ mainClassName = 'ca.nrc.cadc.dlm.client.Main'
 dependencies {
     compile 'log4j:log4j:[1.2,)'
 
-    compile 'org.opencadc:cadc-util:[1.3,)'
+    compile 'org.opencadc:cadc-util:[1.4.2,)'
     compile 'org.opencadc:cadc-log:[1.0,)'
     compile 'org.opencadc:cadc-registry:[1.1.1,)'
     compile 'org.opencadc:cadc-app-kit:[1.0,)'


### PR DESCRIPTION
Making sure the right versions of cadc-util are included, and the runtime dependency for cadc-access-control-identity is included everywhere it needs to be. 

Also for this PR: web/downloadManager cadc9742 branch has similar changes in it's build.gradle. 